### PR TITLE
Added command for removing the postinstall.sh script in vagrant home …

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -194,6 +194,12 @@ sed -i "s/post_max_size = .*/post_max_size = 500M/" /etc/php5/apache2/php.ini
 sed -i "s/upload_max_filesize = .*/upload_max_filesize = 500M/" /etc/php5/apache2/php.ini
 sudo service apache2 restart
 
+#####################################################################
+# Remove postinstall.sh script 										#
+#####################################################################
+rm /home/vagrant/postinstall.sh
+
+
 #######################
 # DONE                #
 #######################


### PR DESCRIPTION
…folder.

The postinstall.sh scripts replaces the public key in /home/vagrant.ssh/authorized_keys (among other things) thus ssh login will stop working after postinstall.sh have been executed

(not tested)
